### PR TITLE
Add environment-based logging 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ data:
       ]
     }
 ```
+
+## Configuration
+
+### Log Level
+
+The log level can be configured using the `LOG_LEVEL` environment variable.
+
+**Default:** `error` (only errors are logged)
+
+**Available levels:** `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`
+

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
         - name: mutator
           image: ghcr.io/mwennrich/mutator:latest
+          env:
+            - name: LOG_LEVEL
+              value: "info"
           ports:
           - containerPort: 8080
             protocol: TCP

--- a/mutator.go
+++ b/mutator.go
@@ -62,7 +62,16 @@ func initFlags() (*config, error) {
 
 func run() error {
 	logrusLogEntry := logrus.NewEntry(logrus.New())
-	logrusLogEntry.Logger.SetLevel(logrus.ErrorLevel)
+
+	// Set log level from environment variable, default to ErrorLevel
+	logLevel := logrus.ErrorLevel
+	if envLogLevel := os.Getenv("LOG_LEVEL"); envLogLevel != "" {
+		if level, err := logrus.ParseLevel(envLogLevel); err == nil {
+			logLevel = level
+		}
+	}
+	logrusLogEntry.Logger.SetLevel(logLevel)
+
 	logger := kwhlogrus.NewLogrus(logrusLogEntry)
 
 	cfg, err := initFlags()
@@ -116,7 +125,7 @@ func run() error {
 
 	// Create mutator.
 	mt := kwhmutating.MutatorFunc(func(_ context.Context, _ *kwhmodel.AdmissionReview, obj metav1.Object) (*kwhmutating.MutatorResult, error) {
-		metaObj, err := handleObject(obj, rules)
+		metaObj, err := handleObject(obj, rules, logger)
 		return &kwhmutating.MutatorResult{MutatedObject: metaObj}, err
 	})
 
@@ -155,7 +164,7 @@ func run() error {
 	return nil
 }
 
-func applyRules(name string, namespace string, kind string, origJson []byte, rules Rules) ([]byte, bool, error) {
+func applyRules(name string, namespace string, kind string, origJson []byte, rules Rules, logger log.Logger) ([]byte, bool, error) {
 	for _, rule := range rules.Rules {
 		// Check if the rule applies to the namespace
 		namespacere, err := regexp.Compile(rule.NamespaceRe)
@@ -192,6 +201,11 @@ func applyRules(name string, namespace string, kind string, origJson []byte, rul
 		patchedJson, err := patch.Apply(origJson)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to apply patch: %w", err)
+		}
+
+		// Log if the object was actually mutated
+		if !reflect.DeepEqual(origJson, patchedJson) {
+			logger.Infof("Object mutated: %s/%s (kind: %s) - rule applied", namespace, name, kind)
 		}
 
 		return patchedJson, true, nil
@@ -235,7 +249,7 @@ func readRules(cfg *config, logger log.Logger) Rules {
 	return rules
 }
 
-func handleObject(obj metav1.Object, rules Rules) (metav1.Object, error) {
+func handleObject(obj metav1.Object, rules Rules, logger log.Logger) (metav1.Object, error) {
 	// Marshal the object to JSON
 	origJSON, err := json.Marshal(obj)
 	if err != nil {
@@ -246,7 +260,7 @@ func handleObject(obj metav1.Object, rules Rules) (metav1.Object, error) {
 	kind := parts[len(parts)-1]
 
 	// Patch the object based on the type
-	patchedJSON, ok, err := applyRules(obj.GetName(), obj.GetNamespace(), kind, origJSON, rules)
+	patchedJSON, ok, err := applyRules(obj.GetName(), obj.GetNamespace(), kind, origJSON, rules, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to patch object: %w", err)
 	}

--- a/mutator.go
+++ b/mutator.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -68,6 +69,10 @@ func run() error {
 	if envLogLevel := os.Getenv("LOG_LEVEL"); envLogLevel != "" {
 		if level, err := logrus.ParseLevel(envLogLevel); err == nil {
 			logLevel = level
+		} else {
+			// Log warning for invalid log level, but continue with default
+			logrusLogEntry.Logger.SetLevel(logrus.WarnLevel)
+			logrusLogEntry.Warnf("Invalid LOG_LEVEL '%s': %v. Using default 'error' level.", envLogLevel, err)
 		}
 	}
 	logrusLogEntry.Logger.SetLevel(logLevel)
@@ -204,7 +209,7 @@ func applyRules(name string, namespace string, kind string, origJson []byte, rul
 		}
 
 		// Log if the object was actually mutated
-		if !reflect.DeepEqual(origJson, patchedJson) {
+		if !bytes.Equal(origJson, patchedJson) {
 			logger.Infof("Object mutated: %s/%s (kind: %s) - rule applied", namespace, name, kind)
 		}
 


### PR DESCRIPTION
Introduce logging configuration based on the `LOG_LEVEL` environment variable and document the available log levels in the README. Enhance mutation notifications with logging for object mutations.